### PR TITLE
fix two strings to match the SFDC terms

### DIFF
--- a/help/marketo/product-docs/crm-sync/salesforce-sync/sfdc-sync-details/sfdc-sync-campaign-sync.md
+++ b/help/marketo/product-docs/crm-sync/salesforce-sync/sfdc-sync-details/sfdc-sync-campaign-sync.md
@@ -27,7 +27,7 @@ Marketo では、プログラムと Salesforce キャンペーンの間に 1 対
 
 ![](assets/image2015-7-8-9-3a43-3a8.png)
 
-Marketo の&#x200B;**[チャネル](/help/marketo/product-docs/administration/tags/create-a-program-channel.md){target="_blank"}**&#x200B;と&#x200B;**[期間原価](/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/understanding-period-costs.md){target="_blank"}**&#x200B;は、**キャンペーンタイプ**&#x200B;および&#x200B;**実費**&#x200B;として Salesforce に同期されます。 この同期は Marketo から Salesforce への&#x200B;**一方向**&#x200B;です。
+Marketo の&#x200B;**[チャネル](/help/marketo/product-docs/administration/tags/create-a-program-channel.md){target="_blank"}**&#x200B;と&#x200B;**[期間原価](/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/understanding-period-costs.md){target="_blank"}**&#x200B;は、**種別**&#x200B;および&#x200B;**キャンペーンの実費**&#x200B;として Salesforce に同期されます。 この同期は Marketo から Salesforce への&#x200B;**一方向**&#x200B;です。
 
 Marketo の&#x200B;**プログラムメンバー**&#x200B;と&#x200B;**[進行状況のステータス](/help/marketo/product-docs/core-marketo-concepts/programs/creating-programs/understanding-program-membership.md){target="_blank"}**&#x200B;は、**Salesforce キャンペーンメンバー**&#x200B;と&#x200B;**キャンペーンメンバーステータス**&#x200B;に同期されます。これは、**双方向同期**&#x200B;であるため、Marketo または Salesforce でおこなわれた変更は両方のシステムに反映されます。
 


### PR DESCRIPTION
I would like to fix the difference between the SFDC terminology used in ExL and SFDC since user can misunderstand the imported column name.
I am requesting this in the form of a PR, not an issue, to ensure that the correction proceeds. If you have any problems with this format, please let me know. If the strings are changed as requested, it does not have to be in the form of a PR merge.